### PR TITLE
Fix Docker Compose version warning

### DIFF
--- a/docker-compose.multi-php.yml
+++ b/docker-compose.multi-php.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   php80:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build:


### PR DESCRIPTION
## Summary
Remove obsolete `version` attribute from Docker Compose files to eliminate warning messages.

## Issue
Docker Compose was showing this warning:
```
WARN[0000] /home/mb/Projekte/php-code-intel/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

## Changes Made
- Removed `version: '3.8'` from `docker-compose.yml`
- Removed `version: '3.8'` from `docker-compose.multi-php.yml`
- Docker Compose now auto-detects the schema version

## Technical Details
The `version` attribute was deprecated in Docker Compose v2.x and is now automatically detected based on the features used in the file. Modern Docker Compose (v2.0+) no longer requires explicit version specification.

## Testing
- [x] `docker-compose config` validates successfully
- [x] No warning messages appear
- [x] Both standard and multi-PHP compose files work correctly
- [x] All existing functionality preserved

## Compatibility
- ✅ Docker Compose v2.0+ (recommended)
- ✅ Docker Compose v1.27+ (legacy support)
- ✅ All existing Docker workflows unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)